### PR TITLE
Limit index of hit by j=0

### DIFF
--- a/python/GMesh.py
+++ b/python/GMesh.py
@@ -247,6 +247,8 @@ class GMesh:
         nn_j = np.floor(0.5+(self.lat-lat[0])/dellat)
         nn_i = np.minimum(nn_i, sni-1)
         nn_j = np.minimum(nn_j, snj-1)
+        nn_i = np.maximum(nn_i, 0)
+        nn_j = np.maximum(nn_j, 0)
         assert nn_j.min()>=0, 'Negative j index calculated! j='+str(nn_j.min())
         assert nn_j.max()<snj, 'Out of bounds j index calculated! j='+str(nn_j.max())+'snj='+str(snj)
         assert nn_i.min()>=0, 'Negative i index calculated! i='+str(nn_i.min())

--- a/python/create_topog_refinedSampling.py
+++ b/python/create_topog_refinedSampling.py
@@ -43,7 +43,7 @@ def write_topog(h,hstd,hmin,hmax,xx,yy,fnam=None,format='NETCDF3_CLASSIC',descri
     fout=nc.Dataset(fnam,'w',format=format)
 
     ny=h.shape[0]; nx=h.shape[1]
-    print ('Writing netcdf file with ny,nx= ',ny,nx)
+    print ('Writing netcdf file ',fnam,' with ny,nx= ',ny,nx)
 
     ny=fout.createDimension('ny',ny)
     nx=fout.createDimension('nx',nx)

--- a/python/ice9.py
+++ b/python/ice9.py
@@ -79,6 +79,12 @@ def applyIce9(fileName, nFileName, variable, i0, j0, shallow, analyze):
   #notLand = ice9it(600,270,depth)
   #notLand = ice9it(1200,540,depth) #0.125 deg
   #notLand = ice9it(150,130,depth) #1deg and 0.5deg
+  while depth[j0,i0] >= 0: 
+     print("Seed is not wet! Increasing jseed by 10")
+     j0 += 10
+  if depth[j0,i0] >= 0:
+     error("There is a problem with seed that could not be resolved. The seed location is not in the ocean!")  
+	
   notLand = ice9it(i0,j0,depth)
 
   rgWet = rg.createVariable('wet','f4',('ny','nx'))


### PR DESCRIPTION
- The tool sometimes crashes by finding j=-1 for the source index
  i index was fixed before by limiting it to imin. Why not j?
  Why does this happen at all?